### PR TITLE
Update reverse_client.php example to use doNormal()

### DIFF
--- a/examples/reverse_client.php
+++ b/examples/reverse_client.php
@@ -23,7 +23,7 @@ echo "Sending job\n";
 # Send reverse job
 do
 {
-  $result= $gmclient->do("reverse", "Hello!");
+  $result = $gmclient->doNormal("reverse", "Hello!");
   # Check for various return packets and errors.
   switch($gmclient->returnCode())
   {


### PR DESCRIPTION
`do()` is a reserved word in PHP7, and is deprecated.
