### PR TITLE
add travis ci support using non thread safe PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+dist: trusty
+language: c
+
+addons:
+  apt:
+    sources:
+        - sourceline: 'deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main'
+    packages:
+        - gearman-job-server
+        - libgearman-dev
+        - gearman-tools
+        - php7.0-cli
+        - php7.0-dev
+
+script:
+    - php --version
+    - phpize
+    - ./configure
+    - make
+    - REPORT_EXIT_STATUS=1 make test

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+Build Status: https://travis-ci.org/wcgallego/pecl-gearman
+
 The Gearman PHP Extension provides a wrapper to libgearman. This
 gives the user the ability to write fully featured Gearman clients
 and workers in PHP, allowing them to quickly develop distributed


### PR DESCRIPTION
This add `.travis.yml` to enable Travis CI integration.

The PHP provided by travis is the thread safe version, which will unfortunately break `tests/gearman_client_011.php` with a weird result ("`charset`" is returned instead of "`context1`").

Unless travis provides a NTS version of PHP (see https://github.com/travis-ci/travis-ci/issues/2800), we need to work around that, in this case by using PHP7 packages from https://launchpad.net/~ondrej/+archive/ubuntu/php

It might be a good idea to convert the README to a README.md to enable the status images.
