### PR TITLE
fix client context length

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -2871,7 +2871,7 @@ PHP_FUNCTION(gearman_client_clear_callbacks) {
 /* {{{ proto string GearmanClient::context()
    Get the application data */
 PHP_FUNCTION(gearman_client_context) {
-	const uint8_t *data;
+	const char *data;
 
 	gearman_client_obj *obj;
 	zval *zobj;
@@ -2883,7 +2883,7 @@ PHP_FUNCTION(gearman_client_context) {
 
 	data = gearman_client_context(&(obj->client));
 
-	RETURN_STRINGL((char *)data, (long) sizeof(data));
+	RETURN_STRINGL(data, strlen(data));
 }
 /* }}} */
 

--- a/tests/gearman_client_011.phpt
+++ b/tests/gearman_client_011.phpt
@@ -6,18 +6,18 @@ GearmanClient::context(), GearmanClient::setContext(), gearman_client_context(),
 <?php 
 
 $client = new GearmanClient();
-print "GearmanClient::setContext(OO): " . ($client->setContext('context1') ? 'Success' : 'Failure') . PHP_EOL;
+print "GearmanClient::setContext(OO): " . ($client->setContext('context1_context1_context1_context1') ? 'Success' : 'Failure') . PHP_EOL;
 print "GearmanClient::context (OO): " . $client->context() . PHP_EOL;
 
 $client2 = gearman_client_create();
-print "gearman_client_set_context (Procedural): " . (gearman_client_set_context($client2, 'context2') ? 'Success' : 'Failure') . PHP_EOL;
+print "gearman_client_set_context (Procedural): " . (gearman_client_set_context($client2, 'context2_context2') ? 'Success' : 'Failure') . PHP_EOL;
 print "gearman_client_context (Procedural): " . gearman_client_context($client2) . PHP_EOL;
 
 print "OK";
 ?>
 --EXPECT--
 GearmanClient::setContext(OO): Success
-GearmanClient::context (OO): context1
+GearmanClient::context (OO): context1_context1_context1_context1
 gearman_client_set_context (Procedural): Success
-gearman_client_context (Procedural): context2
+gearman_client_context (Procedural): context2_context2
 OK


### PR DESCRIPTION
This bug showed up while playing with #26 

Beside that `tests/gearman_client_011.phpt` will fail on a thread safe version of PHP, the context string is limited to a length of 8 characters on 64bit platform, and 4 on a 32bit platform, depending on what the pointer size is for the given platform.

I'm not sure if the context string is a plain C-string which must be terminated by NULL or if NULL-character might be valid input to gearman_client_set_context. Since the type is `void*` in libgearman, it might be OK to use C-string in setter and getter.
