### PR TITLE
Minor fixes and tests

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -2284,10 +2284,7 @@ static void gearman_client_add_task_handler(gearman_task_st* (*add_task_func)(
 	task = Z_GEARMAN_TASK_P(return_value);
 
 	if (zdata) {
-		if (Z_REFCOUNTED_P(zdata)) {
-			Z_ADDREF_P(zdata);
-		}
-		ZVAL_COPY_VALUE(&task->zdata, zdata);
+		ZVAL_COPY(&task->zdata, zdata);
 	}
 
 	ZVAL_COPY(&task->zworkload, zworkload);
@@ -2394,10 +2391,7 @@ PHP_FUNCTION(gearman_client_add_task_status) {
 	   task = Z_GEARMAN_TASK_P(return_value);
 
 	if (zdata) {
-		   if (Z_REFCOUNTED_P(zdata)) {
-			   Z_ADDREF_P(zdata);
-		   }
-		   ZVAL_COPY_VALUE(&task->zdata, zdata);
+		   ZVAL_COPY(&task->zdata, zdata);
 	}
 	/* need to store a ref to the client for later access to cb's */
 	ZVAL_COPY(&task->zclient, zobj);
@@ -2540,7 +2534,7 @@ PHP_FUNCTION(gearman_client_set_workload_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zworkload_fn, zworkload_fn);
+	ZVAL_COPY(&obj->zworkload_fn, zworkload_fn);
 
 	/* set the callback for php */
 	gearman_client_set_workload_fn(&(obj->client), _php_task_workload_fn);
@@ -2579,7 +2573,7 @@ PHP_FUNCTION(gearman_client_set_created_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zcreated_fn, zcreated_fn);
+	ZVAL_COPY(&obj->zcreated_fn, zcreated_fn);
 
 	/* set the callback for php */
 	gearman_client_set_created_fn(&(obj->client), _php_task_created_fn);
@@ -2618,7 +2612,7 @@ PHP_FUNCTION(gearman_client_set_data_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zdata_fn, zdata_fn);
+	ZVAL_COPY(&obj->zdata_fn, zdata_fn);
 
 	/* set the callback for php */
 	gearman_client_set_data_fn(&(obj->client), _php_task_data_fn);
@@ -2657,7 +2651,7 @@ PHP_FUNCTION(gearman_client_set_warning_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zwarning_fn, zwarning_fn);
+	ZVAL_COPY(&obj->zwarning_fn, zwarning_fn);
 
 	/* set the callback for php */
 	gearman_client_set_warning_fn(&(obj->client), _php_task_warning_fn);
@@ -2697,7 +2691,7 @@ PHP_FUNCTION(gearman_client_set_status_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zstatus_fn, zstatus_fn);
+	ZVAL_COPY(&obj->zstatus_fn, zstatus_fn);
 
 	/* set the callback for php */
 	gearman_client_set_status_fn(&(obj->client), _php_task_status_fn);
@@ -2736,7 +2730,7 @@ PHP_FUNCTION(gearman_client_set_complete_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zcomplete_fn, zcomplete_fn);
+	ZVAL_COPY(&obj->zcomplete_fn, zcomplete_fn);
 
 	/* set the callback for php */
 	gearman_client_set_complete_fn(&(obj->client), _php_task_complete_fn);
@@ -2775,7 +2769,7 @@ PHP_FUNCTION(gearman_client_set_exception_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zexception_fn, zexception_fn);
+	ZVAL_COPY(&obj->zexception_fn, zexception_fn);
 
 	/* set the callback for php */
 	gearman_client_set_exception_fn(&(obj->client), _php_task_exception_fn);
@@ -2820,7 +2814,7 @@ PHP_FUNCTION(gearman_client_set_fail_callback) {
 	}
 
 	/* store the cb in client object */
-	ZVAL_DUP(&obj->zfail_fn, zfail_fn);
+	ZVAL_COPY(&obj->zfail_fn, zfail_fn);
 
 	/* set the callback for php */
 	gearman_client_set_fail_fn(&(obj->client), _php_task_fail_fn);

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -2035,7 +2035,7 @@ static void gearman_client_do_background_work_handler(gearman_return_t (*do_back
 								const char *unique,
 								const void *workload,
 								size_t workload_size,
-						  			gearman_job_handle_t job_handle
+								gearman_job_handle_t job_handle
 					),
 					INTERNAL_FUNCTION_PARAMETERS) {
 	char *function_name;
@@ -2273,6 +2273,10 @@ static void gearman_client_add_task_handler(gearman_task_st* (*add_task_func)(
 
 	if (unique_len == 0) {
 	  unique = NULL;
+	}
+
+	if (Z_TYPE_P(zworkload) != IS_STRING) {
+		convert_to_string(zworkload);
 	}
 
 	/* get a task object, and prepare it for return */

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -1690,10 +1690,14 @@ PHP_METHOD(GearmanClient, __construct)
    cleans up GearmanClient object */
 PHP_METHOD(GearmanClient, __destruct)
 {
+	char *context = NULL;
 	gearman_client_obj *intern = Z_GEARMAN_CLIENT_P(getThis());
 	if (!intern) {
 		return;
 	}
+
+	context = gearman_client_context(&(intern->client));
+	efree(context);
 
 	if (intern->flags & GEARMAN_CLIENT_OBJ_CREATED) {
 		gearman_client_free(&intern->client);
@@ -2875,7 +2879,7 @@ PHP_FUNCTION(gearman_client_context) {
 /* {{{ proto bool GearmanClient::setContext(string data)
    Set the application data */
 PHP_FUNCTION(gearman_client_set_context) {
-	char *data;
+	char *data, *old_context;
 	size_t data_len = 0;
 
 	gearman_client_obj *obj;
@@ -2886,7 +2890,10 @@ PHP_FUNCTION(gearman_client_set_context) {
 	}
 	obj = Z_GEARMAN_CLIENT_P(zobj);
 
-	gearman_client_set_context(&(obj->client), (void *)data);
+	old_context = gearman_client_context(&(obj->client));
+	efree(old_context);
+
+	gearman_client_set_context(&(obj->client), (void*) estrndup(data, data_len));
 	RETURN_TRUE;
 }
 /* }}} */

--- a/tests/connect.inc
+++ b/tests/connect.inc
@@ -1,4 +1,4 @@
 <?php
 
-$host = getenv("GEARMAN_TEST_HOST") ? getenv("GEARMAN_TEST_HOST") : "localhost";
-$port = getenv("GEARMAN_TEST_PORT") ? getenv("GEARMAN_TEST_PORT") : 4730;
+$host = getenv("GEARMAN_TEST_HOST") ?: "localhost";
+$port = getenv("GEARMAN_TEST_PORT") ?: 4730;

--- a/tests/connect.inc
+++ b/tests/connect.inc
@@ -1,0 +1,4 @@
+<?php
+
+$host = getenv("GEARMAN_TEST_HOST") ? getenv("GEARMAN_TEST_HOST") : "localhost";
+$port = getenv("GEARMAN_TEST_PORT") ? getenv("GEARMAN_TEST_PORT") : 4730;

--- a/tests/gearman_tasks_integration_test_001.phpt
+++ b/tests/gearman_tasks_integration_test_001.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Test Gearman worker methods
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnect.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+
+print "Start\n";
+
+$job_name = uniqid();
+
+$pid = pcntl_fork();
+if ($pid == -1) {
+    die("Could not fork");
+} else if ($pid > 0) {
+    // Parent. This is the worker
+    $worker = new GearmanWorker();
+    var_dump($worker->addServer($host, $port));
+    var_dump(
+        $worker->addFunction(
+            $job_name,
+            function($job) {
+                var_dump($job->workload());
+            }
+        )
+    );
+
+    for ($i = 0; $i < 6; $i++) {
+        $worker->work();
+    }
+
+    var_dump($worker->unregister($job_name));
+
+    // Wait for child
+    $exit_status = 0;
+    if (pcntl_wait($exit_status) <= 0) {
+        print "pcntl_wait exited with error\n";
+    } else if (!pcntl_wifexited($exit_status)) {
+        print "child exited with error\n";
+    }
+} else {
+    //Child. This is the client. Don't echo anything here
+    $client = new GearmanClient();
+    if ($client->addServer($host, $port) !== true) {
+        exit(1); // error
+    };
+
+    $tasks = [];
+    $tasks[] = $client->addTask($job_name, "normal");
+    $tasks[] = $client->addTaskBackground($job_name, "normalbg");
+    $tasks[] = $client->addTaskHigh($job_name, 1);
+    $tasks[] = $client->addTaskHighBackground($job_name, 2.0);
+    $tasks[] = $client->addTaskLow($job_name, "low");
+    $tasks[] = $client->addTaskLowBackground($job_name, true);
+    $client->runTasks();
+    if ($client->returnCode() != GEARMAN_SUCCESS) {
+        exit(2); // error
+    }
+    exit(0);
+}
+
+print "Done";
+--EXPECTF--
+Start
+bool(true)
+bool(true)
+string(1) "2"
+string(1) "1"
+string(8) "normalbg"
+string(6) "normal"
+string(1) "1"
+string(3) "low"
+bool(true)
+Done

--- a/tests/gearman_tasks_integration_test_001.phpt
+++ b/tests/gearman_tasks_integration_test_001.phpt
@@ -9,7 +9,7 @@ require_once('skipifconnect.inc');
 <?php
 require_once('connect.inc');
 
-print "Start\n";
+print "Start" . PHP_EOL;
 
 $job_name = uniqid();
 
@@ -19,28 +19,29 @@ if ($pid == -1) {
 } else if ($pid > 0) {
     // Parent. This is the worker
     $worker = new GearmanWorker();
-    var_dump($worker->addServer($host, $port));
-    var_dump(
+    print "addServer: " . var_export($worker->addServer($host, $port), true) . PHP_EOL;
+    print "addFunction: " . var_export(
         $worker->addFunction(
             $job_name,
             function($job) {
-                var_dump($job->workload());
+                print "workload: " . var_export($job->workload(), true) . PHP_EOL;
             }
-        )
-    );
+        ),
+        true
+    ) . PHP_EOL;
 
     for ($i = 0; $i < 6; $i++) {
         $worker->work();
     }
 
-    var_dump($worker->unregister($job_name));
+    print "unregister: " . var_export($worker->unregister($job_name), true) . PHP_EOL;
 
     // Wait for child
     $exit_status = 0;
     if (pcntl_wait($exit_status) <= 0) {
-        print "pcntl_wait exited with error\n";
+        print "pcntl_wait exited with error" . PHP_EOL;
     } else if (!pcntl_wifexited($exit_status)) {
-        print "child exited with error\n";
+        print "child exited with error" . PHP_EOL;
     }
 } else {
     //Child. This is the client. Don't echo anything here
@@ -66,13 +67,13 @@ if ($pid == -1) {
 print "Done";
 --EXPECTF--
 Start
-bool(true)
-bool(true)
-string(1) "2"
-string(1) "1"
-string(8) "normalbg"
-string(6) "normal"
-string(1) "1"
-string(3) "low"
-bool(true)
+addServer: true
+addFunction: true
+workload: '2'
+workload: '1'
+workload: 'normalbg'
+workload: 'normal'
+workload: '1'
+workload: 'low'
+unregister: true
 Done

--- a/tests/gearman_tasks_integration_test_002.phpt
+++ b/tests/gearman_tasks_integration_test_002.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Test Gearman worker methods
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnect.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+
+print "Start\n";
+
+$job_name = uniqid();
+
+$pid = pcntl_fork();
+if ($pid == -1) {
+    die("Could not fork");
+} else if ($pid == 0) {
+    // Child. This is the worker.
+    // Don't echo anything here
+    $worker = new GearmanWorker();
+    $worker->addServer($host, $port);
+    $worker->addFunction(
+        $job_name,
+        function($job) {
+            if ($job->workload() == "success") {
+                return "done";
+            } else if ($job->workload() == "exception") {
+                $job->sendException("unhandled");
+                return "exception";
+            } else if ($job->workload() == "fail") {
+                $job->sendFail();
+                return "fail";
+            }
+        }
+    );
+
+    for ($i = 0; $i < 3; $i++) {
+        $worker->work();
+    }
+
+    $worker->unregister($job_name);
+    exit(0);
+} else {
+    //Parent. This is the client.
+    $client = new GearmanClient();
+    if ($client->addServer($host, $port) !== true) {
+        exit(1); // error
+    };
+
+    $client->setCompleteCallback(function($task) {
+        print "Complete: " . $task->data() . "\n";
+    });
+    $client->setDataCallback(function($task) {
+        print "Data: " . $task->data() . "\n";
+    });
+    $client->setExceptionCallback(function($task) {
+        print "Exception: " . $task->data() . "\n";
+    });
+    $client->setFailCallback(function($task) {
+        print "Fail\n";
+    });
+
+    $tasks = [];
+    $tasks[] = $client->addTask($job_name, "success");
+    $tasks[] = $client->addTask($job_name, "fail");
+    $tasks[] = $client->addTask($job_name, "exception");
+    $client->runTasks();
+    var_dump($client->returnCode());
+    var_dump($client->clearCallbacks());
+
+    // Wait for child
+    $exit_status = 0;
+    if (pcntl_wait($exit_status) <= 0) {
+        print "pcntl_wait exited with error\n";
+    } else if (!pcntl_wifexited($exit_status)) {
+        print "child exited with error\n";
+    }
+}
+
+print "Done";
+--EXPECTF--
+Start
+Exception: unhandled
+Complete: exception
+Fail
+Complete: done
+int(0)
+bool(true)
+Done

--- a/tests/gearman_tasks_integration_test_002.phpt
+++ b/tests/gearman_tasks_integration_test_002.phpt
@@ -9,7 +9,7 @@ require_once('skipifconnect.inc');
 <?php
 require_once('connect.inc');
 
-print "Start\n";
+print "Start" . PHP_EOL;
 
 $job_name = uniqid();
 
@@ -50,16 +50,16 @@ if ($pid == -1) {
     };
 
     $client->setCompleteCallback(function($task) {
-        print "Complete: " . $task->data() . "\n";
+        print "Complete: " . $task->data() . PHP_EOL;
     });
     $client->setDataCallback(function($task) {
-        print "Data: " . $task->data() . "\n";
+        print "Data: " . $task->data() . PHP_EOL;
     });
     $client->setExceptionCallback(function($task) {
-        print "Exception: " . $task->data() . "\n";
+        print "Exception: " . $task->data() . PHP_EOL;
     });
     $client->setFailCallback(function($task) {
-        print "Fail\n";
+        print "Fail" . PHP_EOL;
     });
 
     $tasks = [];
@@ -67,15 +67,15 @@ if ($pid == -1) {
     $tasks[] = $client->addTask($job_name, "fail");
     $tasks[] = $client->addTask($job_name, "exception");
     $client->runTasks();
-    var_dump($client->returnCode());
-    var_dump($client->clearCallbacks());
+    print "returnCode: " . var_export($client->returnCode(), true) . PHP_EOL;
+    print "clearCallbacks: " . var_export($client->clearCallbacks(), true) . PHP_EOL;
 
     // Wait for child
     $exit_status = 0;
     if (pcntl_wait($exit_status) <= 0) {
-        print "pcntl_wait exited with error\n";
+        print "pcntl_wait exited with error" . PHP_EOL;
     } else if (!pcntl_wifexited($exit_status)) {
-        print "child exited with error\n";
+        print "child exited with error" . PHP_EOL;
     }
 }
 
@@ -86,6 +86,6 @@ Exception: unhandled
 Complete: exception
 Fail
 Complete: done
-int(0)
-bool(true)
+returnCode: 0
+clearCallbacks: true
 Done

--- a/tests/gearman_worker_integration_test_001.phpt
+++ b/tests/gearman_worker_integration_test_001.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Test Gearman worker methods
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnect.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+
+print "Start\n";
+$job_name = uniqid();
+$pid = pcntl_fork();
+if ($pid == -1) {
+    die("Could not fork");
+} else if ($pid > 0) {
+    // Parent. This is the worker
+    $worker = new GearmanWorker();
+    var_dump($worker->addServer($host, $port));
+    var_dump($worker->setTimeout(5));
+    var_dump($worker->register($job_name, 5));
+    var_dump($worker->register($job_name . "1", 5));
+    var_dump($worker->register($job_name . "2", 5));
+    var_dump($worker->register($job_name . "3", 5));
+    var_dump(
+        $worker->addFunction(
+            $job_name,
+            function($job) {
+                var_dump($job->workload());
+            }
+        )
+    );
+    var_dump($worker->work());
+    var_dump($worker->unregister($job_name));
+    var_dump($worker->unregisterAll());
+
+    // Wait for child
+    $exit_status = 0;
+    if (pcntl_wait($exit_status) <= 0) {
+        print "pcntl_wait exited with error\n";
+    } else if (!pcntl_wifexited($exit_status)) {
+        print "child exited with error\n";
+    }
+} else {
+    //Child. This is the client. Don't echo anything here
+    $client = new GearmanClient();
+    if ($client->addServer($host, $port) !== true) {
+        exit(1); // error
+    };
+    $client->doBackground($job_name, "nothing");
+    if ($client->returnCode() != GEARMAN_SUCCESS) {
+        exit(2); // error
+    }
+    exit(0);
+}
+
+print "Done";
+--EXPECTF--
+Start
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+string(7) "nothing"
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/gearman_worker_integration_test_001.phpt
+++ b/tests/gearman_worker_integration_test_001.phpt
@@ -9,7 +9,7 @@ require_once('skipifconnect.inc');
 <?php
 require_once('connect.inc');
 
-print "Start\n";
+print "Start" . PHP_EOL;
 $job_name = uniqid();
 $pid = pcntl_fork();
 if ($pid == -1) {
@@ -17,30 +17,30 @@ if ($pid == -1) {
 } else if ($pid > 0) {
     // Parent. This is the worker
     $worker = new GearmanWorker();
-    var_dump($worker->addServer($host, $port));
-    var_dump($worker->setTimeout(5));
-    var_dump($worker->register($job_name, 5));
-    var_dump($worker->register($job_name . "1", 5));
-    var_dump($worker->register($job_name . "2", 5));
-    var_dump($worker->register($job_name . "3", 5));
-    var_dump(
+    print "addServer: " . var_export($worker->addServer($host, $port), true) . PHP_EOL;
+    print "setTimeout: " . var_export($worker->setTimeout(5), true) . PHP_EOL;
+    print "register: " . var_export($worker->register($job_name, 5), true) . PHP_EOL;
+    print "register: " . var_export($worker->register($job_name . "1", 5), true) . PHP_EOL;
+    print "register: " . var_export($worker->register($job_name . "2", 5), true) . PHP_EOL;
+    print "register: " . var_export($worker->register($job_name . "3", 5), true) . PHP_EOL;
+    print "addFunction: " . var_export(
         $worker->addFunction(
             $job_name,
             function($job) {
-                var_dump($job->workload());
+                print "workload: " . var_export($job->workload(), true) . PHP_EOL;
             }
-        )
-    );
-    var_dump($worker->work());
-    var_dump($worker->unregister($job_name));
-    var_dump($worker->unregisterAll());
+        ), true
+    ) . PHP_EOL;
+    print "work: " . var_export($worker->work(), true) . PHP_EOL;
+    print "unregister: " . var_export($worker->unregister($job_name), true) . PHP_EOL;
+    print "unregisterAll: " . var_export($worker->unregisterAll(), true) . PHP_EOL;
 
     // Wait for child
     $exit_status = 0;
     if (pcntl_wait($exit_status) <= 0) {
-        print "pcntl_wait exited with error\n";
+        print "pcntl_wait exited with error" . PHP_EOL;
     } else if (!pcntl_wifexited($exit_status)) {
-        print "child exited with error\n";
+        print "child exited with error" . PHP_EOL;
     }
 } else {
     //Child. This is the client. Don't echo anything here
@@ -58,15 +58,15 @@ if ($pid == -1) {
 print "Done";
 --EXPECTF--
 Start
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-string(7) "nothing"
-bool(true)
-bool(true)
-bool(true)
+addServer: true
+setTimeout: true
+register: true
+register: true
+register: true
+register: true
+addFunction: true
+workload: 'nothing'
+work: true
+unregister: true
+unregisterAll: true
 Done

--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -1,0 +1,9 @@
+<?php
+
+if (!extension_loaded("gearman")) {
+    die("skip gearman extension unavailable");
+}
+
+if (!extension_loaded("pcntl")) {
+    die("skip pcntl extension unavailable");
+}

--- a/tests/skipifconnect.inc
+++ b/tests/skipifconnect.inc
@@ -1,0 +1,23 @@
+<?php
+
+require_once('connect.inc');
+
+$sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+if ($sock === false) {
+    die("skip unable to create socket");
+}
+
+if (socket_connect($sock, $host, $port) !== true) {
+    die("skip unable to connect");
+}
+
+$command = "getpid\n";
+if (socket_write($sock, $command) !== strlen($command)) {
+    die("skip unable to write getpid");
+}
+
+if (socket_read($sock, 8) === false) {
+    die("skip unable to read pid");
+}
+
+socket_close($sock);


### PR DESCRIPTION
Fixes a SEGV due to incorrect handling of ref counts

```
==16021== Invalid read of size 1
==16021==    at 0x7FE441: _zval_dtor_func (zend_variables.c:33)
==16021==    by 0x23E2A822: _zval_dtor (zend_variables.h:44)
==16021==    by 0x23E2A822: zim_GearmanTask___destruct (php_gearman.c:3682)
==16021==    by 0x7F1EC5: zend_call_function (zend_execute_API.c:885)
==16021==    by 0x81DB72: zend_call_method (zend_interfaces.c:104)
==16021==    by 0x83632E: zend_objects_destroy_object (zend_objects.c:148)
==16021==    by 0x83AF8A: zend_objects_store_del (zend_objects_API.c:160)
==16021==    by 0x8111C6: UnknownInlinedFun (zend_variables.h:58)
==16021==    by 0x8111C6: zend_array_destroy (zend_hash.c:1335)
==16021==    by 0x23E2A792: _zval_dtor (zend_variables.h:44)
==16021==    by 0x23E2A792: zim_GearmanClient___destruct (php_gearman.c:1721)
==16021==    by 0x7F1EC5: zend_call_function (zend_execute_API.c:885)
==16021==    by 0x81DB72: zend_call_method (zend_interfaces.c:104)
==16021==    by 0x83632E: zend_objects_destroy_object (zend_objects.c:148)
==16021==    by 0x83AB30: zend_objects_store_call_destructors (zend_objects_API.c:54)
==16021==  Address 0x2e96c9fc is 2,556 bytes inside a block of size 2,592 free'd
==16021==    at 0x4C2AD17: free (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==16021==    by 0x83ADC9: zend_objects_store_del (zend_objects_API.c:187)
==16021==    by 0x23E2A822: _zval_dtor (zend_variables.h:44)
==16021==    by 0x23E2A822: zim_GearmanTask___destruct (php_gearman.c:3682)
==16021==    by 0x7F1EC5: zend_call_function (zend_execute_API.c:885)
==16021==    by 0x81DB72: zend_call_method (zend_interfaces.c:104)
==16021==    by 0x83632E: zend_objects_destroy_object (zend_objects.c:148)
==16021==    by 0x83AF8A: zend_objects_store_del (zend_objects_API.c:160)
==16021==    by 0x8111C6: UnknownInlinedFun (zend_variables.h:58)
==16021==    by 0x8111C6: zend_array_destroy (zend_hash.c:1335)
==16021==    by 0x23E2A792: _zval_dtor (zend_variables.h:44)
==16021==    by 0x23E2A792: zim_GearmanClient___destruct (php_gearman.c:1721)
==16021==    by 0x7F1EC5: zend_call_function (zend_execute_API.c:885)
==16021==    by 0x81DB72: zend_call_method (zend_interfaces.c:104)
==16021==    by 0x83632E: zend_objects_destroy_object (zend_objects.c:148)
....
```
