### PR TITLE
compile issue with gearman_task_fetch_object(). fixed by removing the inline keyword

### DIFF
--- a/php_gearman_task.h
+++ b/php_gearman_task.h
@@ -46,7 +46,7 @@ typedef struct {
         zend_object std;
 } gearman_task_obj;
 
-inline gearman_task_obj *gearman_task_fetch_object(zend_object *obj);
+gearman_task_obj *gearman_task_fetch_object(zend_object *obj);
 #define Z_GEARMAN_TASK_P(zv) gearman_task_fetch_object(Z_OBJ_P((zv)))
 
 gearman_return_t _php_task_cb_fn(gearman_task_obj *task, gearman_client_obj *client, zval zcall);


### PR DESCRIPTION
Hey Guys,

I too had the issue when compiling for Ubuntu 16.04.1 LTS.

During compile I got,

```
libtool: compile:  cc -I. -I/root/pecl-gearman -DPHP_ATOM_INC -I/root/pecl-gearman/include -I/root/pecl-gearman/main -I/root/pecl-gearman -I/usr/include/php/20151011012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -DHAVE_CONFIG_Hcl-gearman/php_gearman.c  -fPIC -DPIC -o .libs/php_gearman.o
In file included from /root/pecl-gearman/php_gearman.c:21:0:
/root/pecl-gearman/php_gearman_task.h:49:26: warning: inline function ‘gearman_task_fetch_object’ declared but never defined
 inline gearman_task_obj *gearman_task_fetch_object(zend_object *obj);
                          ^
```

and doing a nm shows that the symbol does not exist,

```
# nm gearman.so |grep fetch
0000000000011d40 T gearman_client_fetch_object
```

I fixed the issue by removing the inline keyword in the function header file. So far haven't had any issues after that.
