### PR TITLE
Fix duplicate symbols on OS X fixes #36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
-sudo: required
-dist: trusty
 language: php
-php:
-    - '7.0'
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      php: 7.0
+    - os: osx
+      sudo: required
+      language: generic
+      env:
+         - _PHP: 'php70'
 
 addons:
   apt:
@@ -10,6 +18,15 @@ addons:
     - gearman-job-server
     - libgearman-dev
     - gearman-tools
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/dupes ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/versions ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/homebrew-php ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gearman ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew services start gearman ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $_PHP ; fi
 
 script:
     - phpize

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -28,6 +28,16 @@
 #include <libgearman-1.0/interface/status.h>
 #include <libgearman-1.0/status.h>
 
+zend_class_entry *gearman_exception_ce;
+zend_class_entry *gearman_client_ce;
+zend_object_handlers gearman_client_obj_handlers;
+zend_class_entry *gearman_task_ce;
+zend_object_handlers gearman_task_obj_handlers;
+zend_class_entry *gearman_job_ce;
+zend_object_handlers gearman_job_obj_handlers;
+zend_class_entry *gearman_worker_ce;
+zend_object_handlers gearman_worker_obj_handlers;
+
 
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_version, 0, 0, 0)

--- a/php_gearman.h
+++ b/php_gearman.h
@@ -33,7 +33,7 @@ typedef enum {
         GEARMAN_OBJ_CREATED = (1 << 0)
 } gearman_obj_flags_t;
 
-zend_class_entry *gearman_exception_ce;
+extern zend_class_entry *gearman_exception_ce;
 
 #define GEARMAN_EXCEPTION(__error, __error_code) { \
         zend_throw_exception(gearman_exception_ce, __error, __error_code); \

--- a/php_gearman_client.h
+++ b/php_gearman_client.h
@@ -25,8 +25,8 @@
 #include <libgearman-1.0/interface/status.h>
 #include <libgearman-1.0/status.h>
 
-zend_class_entry *gearman_client_ce;
-zend_object_handlers gearman_client_obj_handlers;
+extern zend_class_entry *gearman_client_ce;
+extern zend_object_handlers gearman_client_obj_handlers;
 
 zend_object *gearman_client_obj_new(zend_class_entry *ce);
 

--- a/php_gearman_job.h
+++ b/php_gearman_job.h
@@ -25,8 +25,8 @@
 #include <libgearman-1.0/interface/status.h>
 #include <libgearman-1.0/status.h>
 
-zend_class_entry *gearman_job_ce;
-zend_object_handlers gearman_job_obj_handlers;
+extern zend_class_entry *gearman_job_ce;
+extern zend_object_handlers gearman_job_obj_handlers;
 
 zend_object *gearman_job_obj_new(zend_class_entry *ce);
 

--- a/php_gearman_task.h
+++ b/php_gearman_task.h
@@ -27,8 +27,8 @@
 #include <libgearman-1.0/status.h>
 
 zend_object *gearman_task_obj_new(zend_class_entry *ce);
-zend_class_entry *gearman_task_ce;
-zend_object_handlers gearman_task_obj_handlers;
+extern zend_class_entry *gearman_task_ce;
+extern zend_object_handlers gearman_task_obj_handlers;
 
 typedef enum {
         GEARMAN_TASK_OBJ_CREATED = (1 << 0),

--- a/php_gearman_worker.h
+++ b/php_gearman_worker.h
@@ -27,8 +27,8 @@
 #include <libgearman-1.0/interface/status.h>
 #include <libgearman-1.0/status.h>
 
-zend_class_entry *gearman_worker_ce;
-zend_object_handlers gearman_worker_obj_handlers;
+extern zend_class_entry *gearman_worker_ce;
+extern zend_object_handlers gearman_worker_obj_handlers;
 
 zend_object *gearman_worker_obj_new(zend_class_entry *ce);
 


### PR DESCRIPTION
While Linux seems to be OK, the test `tests/gearman_tasks_integration_test_002.phpt` fails for OS X: https://travis-ci.org/xalopp/pecl-gearman/jobs/160529849 

Maybe someone has some idea how to solves this completely?
