### PR TITLE
Allow using NULL as the last parameter

### DIFF
--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -437,7 +437,7 @@ static void gearman_client_do_background_work_handler(gearman_return_t (*do_back
         gearman_client_obj *obj;
         zval *zobj;
 
-        if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oss|s", &zobj, gearman_client_ce,
+        if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oss|s!", &zobj, gearman_client_ce,
                                                         &function_name, &function_name_len,
                                                         &workload, &workload_len,
                                                         &unique, &unique_len) == FAILURE) {


### PR DESCRIPTION
Cutted example:
```
declare(strict_types=1);

class QueueService
{
    // ... other methods

    public function put(\Serializable $object, string $eventName, array $extraEventData, string $uniqueId = null)
    {
        return DI::gearman_client()->doBackground(
            $this->queueName,
            serialize(compact('object', 'extraEventData', 'eventName')),
            $uniqueId
        );
    }
}

$QueueServiceObject->put($foo, 'bar', $bar); // FAIL because of strict_types and doBackground requires string uniqueId
```