### PR TITLE
Removed gearman_client_set_server_option call after add_server[s].

### DIFF
--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -293,10 +293,6 @@ PHP_FUNCTION(gearman_worker_add_server) {
                 RETURN_FALSE;
         }
 
-        if (! gearman_worker_set_server_option(&(obj->worker), "exceptions", (sizeof("exceptions") - 1))) {
-                GEARMAN_EXCEPTION("Failed to set exception option", 0);
-        }
-
         RETURN_TRUE;
 }
 /* }}} */
@@ -323,10 +319,6 @@ PHP_FUNCTION(gearman_worker_add_servers) {
                 php_error_docref(NULL, E_WARNING, "%s",
                                                  gearman_worker_error(&obj->worker));
                 RETURN_FALSE;
-        }
-
-        if (! gearman_worker_set_server_option(&(obj->worker), "exceptions", (sizeof("exceptions") - 1))) {
-                GEARMAN_EXCEPTION("Failed to set exception option", 0);
         }
 
         RETURN_TRUE;


### PR DESCRIPTION
Because when we are using multiple job servers, and one of job servers was down, and other was up, this function call will occur fatal error: 'Failed to set exception option'. But libgearman support failover between added servers. 