### PR TITLE
Fix segfault when calling set fail callback, don't call zval_dtor twice

### DIFF
--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -1156,11 +1156,6 @@ PHP_FUNCTION(gearman_client_set_fail_callback) {
 		zval_dtor(&obj->zfail_fn);
 	}
 
-	/* Defining callback again? Clean up old one first */
-	if (!Z_ISUNDEF(obj->zfail_fn)) {
-		zval_dtor(&obj->zfail_fn);
-	}
-
 	/* store the cb in client object */
 	ZVAL_COPY(&obj->zfail_fn, zfail_fn);
 


### PR DESCRIPTION
When running with PHP7 I noticed PHP was segfaulting in the `gearman_client_set_fail_callback` function. After further inspection, it looks like we are trying to call `zval_dtor` twice,, looks to be like these lines were duplicated by accident. As soon as I removed the second `zval_dtor` no more segfault.