### PR TITLE
Add support for SSL connections to gearmand (Issue #43)

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -349,6 +349,21 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_set_timeout, 0, 0, 1)
 	ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_set_ssl, 0, 0, 2)
+	ZEND_ARG_INFO(0, client_object)
+	ZEND_ARG_INFO(0, ssl)
+	ZEND_ARG_INFO(0, ca_file)
+	ZEND_ARG_INFO(0, certificate)
+	ZEND_ARG_INFO(0, key_file)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_set_ssl, 0, 0, 1)
+	ZEND_ARG_INFO(0, ssl)
+	ZEND_ARG_INFO(0, ca_file)
+	ZEND_ARG_INFO(0, certificate)
+	ZEND_ARG_INFO(0, key_file)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_add_server, 0, 0, 1)
 	ZEND_ARG_INFO(0, client_object)
 	ZEND_ARG_INFO(0, host)
@@ -792,6 +807,21 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_set_timeout, 0, 0, 1)
 	ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_worker_set_ssl, 0, 0, 2)
+	ZEND_ARG_INFO(0, worker_object)
+	ZEND_ARG_INFO(0, ssl)
+	ZEND_ARG_INFO(0, ca_file)
+	ZEND_ARG_INFO(0, certificate)
+	ZEND_ARG_INFO(0, key_file)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_set_ssl, 0, 0, 1)
+	ZEND_ARG_INFO(0, ssl)
+	ZEND_ARG_INFO(0, ca_file)
+	ZEND_ARG_INFO(0, certificate)
+	ZEND_ARG_INFO(0, key_file)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_worker_set_id, 0, 0, 2)
 	ZEND_ARG_INFO(0, worker_object)
 	ZEND_ARG_INFO(0, id)
@@ -964,6 +994,7 @@ zend_function_entry gearman_functions[] = {
 	PHP_FE(gearman_client_remove_options, arginfo_gearman_client_remove_options)
 	PHP_FE(gearman_client_timeout, arginfo_gearman_client_timeout)
 	PHP_FE(gearman_client_set_timeout, arginfo_gearman_client_set_timeout)
+	PHP_FE(gearman_client_set_ssl, arginfo_gearman_client_set_ssl)
 	PHP_FE(gearman_client_context, arginfo_gearman_client_context)
 	PHP_FE(gearman_client_set_context, arginfo_gearman_client_set_context)
 	PHP_FE(gearman_client_add_server, arginfo_gearman_client_add_server)
@@ -1024,6 +1055,7 @@ zend_function_entry gearman_functions[] = {
 	PHP_FE(gearman_worker_remove_options, arginfo_gearman_worker_remove_options)
 	PHP_FE(gearman_worker_timeout, arginfo_gearman_worker_timeout)
 	PHP_FE(gearman_worker_set_timeout, arginfo_gearman_worker_set_timeout)
+	PHP_FE(gearman_worker_set_ssl, arginfo_gearman_worker_set_ssl)
 	PHP_FE(gearman_worker_set_id, arginfo_gearman_worker_set_id)
 	PHP_FE(gearman_worker_add_server, arginfo_gearman_worker_add_server)
 	PHP_FE(gearman_worker_add_servers, arginfo_gearman_worker_add_servers)
@@ -1070,6 +1102,7 @@ static zend_function_entry gearman_client_methods[]= {
 	PHP_ME_MAPPING(removeOptions, gearman_client_remove_options, arginfo_oo_gearman_client_remove_options, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(timeout, gearman_client_timeout, arginfo_oo_gearman_client_timeout, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setTimeout, gearman_client_set_timeout, arginfo_oo_gearman_client_set_timeout, ZEND_ACC_PUBLIC)
+	PHP_ME_MAPPING(setSSL, gearman_client_set_ssl, arginfo_oo_gearman_client_set_ssl, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(context, gearman_client_context, arginfo_oo_gearman_client_context, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setContext, gearman_client_set_context, arginfo_oo_gearman_client_set_context, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(addServer, gearman_client_add_server, arginfo_oo_gearman_client_add_server, ZEND_ACC_PUBLIC)
@@ -1140,6 +1173,7 @@ zend_function_entry gearman_worker_methods[]= {
 	PHP_ME_MAPPING(removeOptions, gearman_worker_remove_options, arginfo_oo_gearman_worker_remove_options, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(timeout, gearman_worker_timeout, arginfo_oo_gearman_worker_timeout, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setTimeout, gearman_worker_set_timeout, arginfo_oo_gearman_worker_set_timeout, ZEND_ACC_PUBLIC)
+	PHP_ME_MAPPING(setSSL, gearman_worker_set_ssl, arginfo_oo_gearman_worker_set_ssl, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setId, gearman_worker_set_id, arginfo_oo_gearman_worker_set_id, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(addServer, gearman_worker_add_server, arginfo_oo_gearman_worker_add_server, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(addServers, gearman_worker_add_servers, arginfo_oo_gearman_worker_add_servers, ZEND_ACC_PUBLIC)
@@ -1632,6 +1666,9 @@ PHP_MINIT_FUNCTION(gearman) {
 	REGISTER_LONG_CONSTANT("GEARMAN_CLIENT_FREE_TASKS",
 		GEARMAN_CLIENT_FREE_TASKS,
 		CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("GEARMAN_CLIENT_SSL",
+		GEARMAN_CLIENT_SSL,
+		CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("GEARMAN_CLIENT_STATE_IDLE",
 		GEARMAN_CLIENT_STATE_IDLE,
 		CONST_CS | CONST_PERSISTENT);
@@ -1670,6 +1707,9 @@ PHP_MINIT_FUNCTION(gearman) {
 		CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("GEARMAN_WORKER_TIMEOUT_RETURN",
 		GEARMAN_WORKER_TIMEOUT_RETURN,
+		CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("GEARMAN_WORKER_SSL",
+		GEARMAN_WORKER_SSL,
 		CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("GEARMAN_WORKER_STATE_START",
 		GEARMAN_WORKER_STATE_START,

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -255,6 +255,52 @@ PHP_FUNCTION(gearman_client_set_timeout) {
 }
 /* }}} */
 
+/* {{{ proto bool gearman_client_set_ssl(object client, bool ssl [, string ca_file [, string certificate [, string key_file ]]])
+   Set SSL for a client structure. */
+PHP_FUNCTION(gearman_client_set_ssl) {
+	zend_bool ssl = 0;
+	char *ca_file = NULL;
+	char *certificate = NULL;
+	char *key_file = NULL;
+	size_t ca_file_len = 0;
+	size_t certificate_len = 0;
+	size_t key_file_len = 0;
+
+        gearman_client_obj *obj;
+        zval *zobj;
+
+        if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|bsss",
+					 &zobj, gearman_client_ce,
+					 &ssl, &ca_file, &ca_file_len,
+					 &certificate, &certificate_len,
+					 &key_file, &key_file_len) == FAILURE) {
+                RETURN_FALSE;
+        }
+        obj = Z_GEARMAN_CLIENT_P(zobj);
+
+	if (ca_file == NULL || ca_file_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_ca_file", &ca_file);
+	}
+	if (certificate == NULL || certificate_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_certificate", &certificate);
+	}
+	if (key_file == NULL || key_file_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_key_file", &key_file);
+	}
+/* 	php_error_docref(NULL, E_WARNING, "ssl = %d", (int) ssl); */
+/* 	php_error_docref(NULL, E_WARNING, "ca_file = %s\n", ca_file); */
+/* 	php_error_docref(NULL, E_WARNING, "certificate = %s\n", certificate); */
+/* 	php_error_docref(NULL, E_WARNING, "key_file = %s\n", key_file); */
+	gearman_client_set_ssl(&(obj->client), ssl, ca_file, certificate, key_file);
+        if (obj->ret != GEARMAN_SUCCESS) {
+                php_error_docref(NULL, E_WARNING, "%s",
+                                                 gearman_client_error(&(obj->client)));
+                RETURN_FALSE;
+        }
+	RETURN_TRUE;
+}
+/* }}} */
+
 /* {{{ proto bool gearman_client_add_server(object client [, string host [, int
  * port [, bool setupExceptionHandler ]]])
    Add a job server to a client. This goes into a list of servers than can be used to run tasks. No socket I/O happens here, it is just added to a list. */

--- a/php_gearman_client.h
+++ b/php_gearman_client.h
@@ -118,5 +118,6 @@ PHP_FUNCTION(gearman_client_clear_callbacks);
 PHP_FUNCTION(gearman_client_context);
 PHP_FUNCTION(gearman_client_set_context);
 PHP_FUNCTION(gearman_client_enable_exception_handler);
+PHP_FUNCTION(gearman_client_set_ssl);
 
 #endif  /* __PHP_GEARMAN_CLIENT_H */

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -246,6 +246,49 @@ PHP_FUNCTION(gearman_worker_set_timeout) {
 }
 /* }}} */
 
+/* {{{ proto bool gearman_worker_set_ssl(object worker, bool ssl [, string ca_file [, string certificate [, string key_file ]]])
+   Set SSL for a worker structure. */
+PHP_FUNCTION(gearman_worker_set_ssl) {
+	zend_bool ssl = 0;
+	char *ca_file = NULL;
+	char *certificate = NULL;
+	char *key_file = NULL;
+	size_t ca_file_len = 0;
+	size_t certificate_len = 0;
+	size_t key_file_len = 0;
+
+        gearman_worker_obj *obj;
+        zval *zobj;
+
+        if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|bsss",
+					 &zobj, gearman_client_ce,
+					 &ssl, &ca_file, &ca_file_len,
+					 &certificate, &certificate_len,
+					 &key_file, &key_file_len) == FAILURE) {
+                RETURN_FALSE;
+        }
+        obj = Z_GEARMAN_WORKER_P(zobj);
+
+	if (ca_file == NULL || ca_file_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_ca_file", &ca_file);
+	}
+	if (certificate == NULL || certificate_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_certificate", &certificate);
+	}
+	if (key_file == NULL || key_file_len == (size_t) 0) {
+		cfg_get_string("gearman.ssl_key_file", &key_file);
+	}
+
+	gearman_worker_set_ssl(&(obj->worker), ssl, ca_file, certificate, key_file);
+        if (obj->ret != GEARMAN_SUCCESS) {
+                php_error_docref(NULL, E_WARNING, "%s",
+                                                 gearman_worker_error(&obj->worker));
+                RETURN_FALSE;
+        }
+	RETURN_TRUE;
+}
+/* }}} */
+
 /* {{{ proto void gearman_worker_set_id(object worker, string id)
    Set id for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_id) {

--- a/php_gearman_worker.h
+++ b/php_gearman_worker.h
@@ -77,5 +77,6 @@ PHP_FUNCTION(gearman_worker_grab_job);
 PHP_FUNCTION(gearman_worker_add_function);
 PHP_FUNCTION(gearman_worker_work);
 PHP_FUNCTION(gearman_worker_ping);
+PHP_FUNCTION(gearman_worker_set_ssl);
 
 #endif  /* __PHP_GEARMAN_WORKER_H */


### PR DESCRIPTION
This addresses issue #43. It relies on a version of libgearman.so that supports the `setSSL()` API, which is not yet part of any gearmand release. Refer to https://github.com/gearman/gearmand/issues/63 for details on that issue. These changes are based on chjgcn@gmail.com's patch for some old version of PHP. I heavily modified the code to work with PHP 7.x.

These changes probably need `#ifdef HAVE_LIBGEARMAN_SETSSL` (or something like that) around them in order to support libgearman.so's that have `setSSL()` and those that do not.

I've never actually tested it with a PHP SSL worker. We only use PHP SSL on the client side here....