### PR TITLE
Fix segfaults in PHP 7.4 because free_obj is set to NULL fixes #70 and #73

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -1184,28 +1184,24 @@ PHP_MINIT_FUNCTION(gearman) {
 	gearman_client_ce->create_object = gearman_client_obj_new;
 	memcpy(&gearman_client_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_client_obj_handlers));
 	gearman_client_obj_handlers.offset = XtOffsetOf(gearman_client_obj, std);
-	gearman_client_obj_handlers.free_obj = NULL;
 
 	INIT_CLASS_ENTRY(ce, "GearmanTask", gearman_task_methods);
 	gearman_task_ce = zend_register_internal_class(&ce);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
 	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);
-	gearman_task_obj_handlers.free_obj = NULL;
 
 	INIT_CLASS_ENTRY(ce, "GearmanWorker", gearman_worker_methods);
 	gearman_worker_ce = zend_register_internal_class(&ce);
 	gearman_worker_ce->create_object = gearman_worker_obj_new;
 	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_worker_obj_handlers));
 	gearman_worker_obj_handlers.offset = XtOffsetOf(gearman_worker_obj, std);
-	gearman_worker_obj_handlers.free_obj = NULL;
 
 	INIT_CLASS_ENTRY(ce, "GearmanJob", gearman_job_methods);
 	gearman_job_ce = zend_register_internal_class(&ce);
 	gearman_job_ce->create_object = gearman_job_obj_new;
 	memcpy(&gearman_job_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_job_obj_handlers));
 	gearman_job_obj_handlers.offset = XtOffsetOf(gearman_job_obj, std);
-	gearman_job_obj_handlers.free_obj = NULL;
 
 	/* XXX exception class */
 	INIT_CLASS_ENTRY(ce, "GearmanException", gearman_exception_methods)


### PR DESCRIPTION
`free_obj` is now required in PHP 7.4.
(https://github.com/php/php-src/commit/1cfbb21790ff6dd4931223c5bdc18a0cebf3ffd4)

By default, `free_obj` is set to `zend_object_std_dtor` and there is no need to set it to NULL.